### PR TITLE
#54 Load nodelist file on slave executing the build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/radargun/RadarGunBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/RadarGunBuilder.java
@@ -130,7 +130,7 @@ public class RadarGunBuilder extends Builder {
         RadarGunInstallation rgInstall = getDescriptor().getInstallation(radarGunName);
         build.addAction(new RadarGunInvisibleAction(rgInstall.getHome()));
 
-        NodeList nodes = nodeSource.getNodesList();
+        NodeList nodes = nodeSource.getNodesList(launcher.getChannel());
 
         //check deprecated options
         Functions.checkDeprecatedConfigs(nodes, console);

--- a/src/main/java/org/jenkinsci/plugins/radargun/config/FileNodeConfigSource.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/config/FileNodeConfigSource.java
@@ -3,9 +3,9 @@ package org.jenkinsci.plugins.radargun.config;
 import hudson.Extension;
 import hudson.FilePath;
 
-import java.io.File;
 import java.io.IOException;
 
+import hudson.remoting.VirtualChannel;
 import org.jenkinsci.plugins.radargun.model.impl.NodeList;
 import org.jenkinsci.plugins.radargun.util.ParseUtils;
 import org.jenkinsci.plugins.radargun.util.Resolver;
@@ -25,13 +25,13 @@ public class FileNodeConfigSource extends NodeConfigSource {
     }
     
     @Override
-    public NodeList getNodesList() throws IOException, InterruptedException {
+    public NodeList getNodesList(VirtualChannel slaveChannel) throws IOException, InterruptedException {
         String nodeListPathRes = Resolver.doResolve(nodeListPath);
-        FilePath fp = new FilePath(new File(nodeListPathRes));
+        FilePath fp = new FilePath(slaveChannel, nodeListPathRes);
         String nodes = Resolver.doResolve(fp.readToString());
         return ParseUtils.parseNodeList(nodes);
     }
-    
+
     @Extension
     public static class DescriptorImpl extends NodeSourceDescriptor {
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/radargun/config/NodeConfigSource.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/config/NodeConfigSource.java
@@ -6,6 +6,7 @@ import hudson.model.Descriptor;
 
 import java.io.IOException;
 
+import hudson.remoting.VirtualChannel;
 import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.radargun.model.impl.NodeList;
@@ -19,7 +20,7 @@ import org.jenkinsci.plugins.radargun.model.impl.NodeList;
  */
 public abstract class NodeConfigSource implements Describable<NodeConfigSource> {
 
-    public abstract NodeList getNodesList() throws IOException, InterruptedException;
+    public abstract NodeList getNodesList(VirtualChannel channel) throws IOException, InterruptedException;
 
     @Override
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/jenkinsci/plugins/radargun/config/TextNodeConfigSource.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/config/TextNodeConfigSource.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.radargun.config;
 
 import hudson.Extension;
 
+import hudson.remoting.VirtualChannel;
 import org.jenkinsci.plugins.radargun.model.impl.NodeList;
 import org.jenkinsci.plugins.radargun.util.ParseUtils;
 import org.jenkinsci.plugins.radargun.util.Resolver;
@@ -21,7 +22,7 @@ public class TextNodeConfigSource extends NodeConfigSource {
     }
     
     @Override
-    public NodeList getNodesList() {
+    public NodeList getNodesList(VirtualChannel channel) {
         return ParseUtils.parseNodeList(Resolver.doResolve(nodes));
     }
     


### PR DESCRIPTION
I was wrong on https://github.com/vjuranek/radargun-plugin/issues/54, loading the benchmark from file works.
I'm not 100% sure this will work in real jenkins, but the benchmark file loading is done the same using the FilePath trick.